### PR TITLE
fix(dependencies): update null provider version and requirements

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -6,8 +6,8 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.2.4-alpha.2"
+      version = "~> 3.2"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Updates the null provider to use version constraint "~> 3.2" and
increases the required Terraform version to ">= 1.3" to ensure 
compatibility with the latest features and improvements.